### PR TITLE
Handle ThreatFox failures

### DIFF
--- a/ioc_feeds/fetchers/threatfox.py
+++ b/ioc_feeds/fetchers/threatfox.py
@@ -2,7 +2,7 @@ import requests
 from loguru import logger
 
 
-def fetch_threatfox(url: str, payload: dict, retries: int = 3) -> list[dict]:
+def fetch_threatfox(url: str, payload: dict, retries: int = 3, *, raise_on_fail: bool = True) -> list[dict]:
     for attempt in range(1, retries + 1):
         try:
             logger.info("Fetching ThreatFox data (attempt {}/{})", attempt, retries)
@@ -13,5 +13,8 @@ def fetch_threatfox(url: str, payload: dict, retries: int = 3) -> list[dict]:
         except Exception as e:
             logger.error("Error fetching ThreatFox: {}", e)
             if attempt == retries:
-                raise
+                if raise_on_fail:
+                    raise
+                logger.error("Failed to fetch ThreatFox after {} attempts", retries)
+                return []
     return []

--- a/ioc_feeds/main_etl.py
+++ b/ioc_feeds/main_etl.py
@@ -31,8 +31,15 @@ def run_etl(config_path: str = 'config.yaml'):
 
     threat_cfg = config['sources'].get('threatfox')
     if threat_cfg:
-        data = fetch_threatfox(threat_cfg['url'], threat_cfg.get('api_payload', {}))
-        records.extend(parse_threatfox(data, source='threatfox'))
+        try:
+            data = fetch_threatfox(
+                threat_cfg['url'],
+                threat_cfg.get('api_payload', {}),
+                raise_on_fail=False,
+            )
+            records.extend(parse_threatfox(data, source='threatfox'))
+        except Exception as e:
+            logger.error("ThreatFox fetch failed: {}", e)
 
     db_handler.insert_many(records)
 

--- a/ioc_feeds/tests/test_fetchers.py
+++ b/ioc_feeds/tests/test_fetchers.py
@@ -1,0 +1,26 @@
+import pytest
+from ioc_feeds.fetchers.threatfox import fetch_threatfox
+
+
+class DummyResp:
+    def __init__(self, status=200, data=None):
+        self.status_code = status
+        self._data = data or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError('bad status')
+
+    def json(self):
+        return self._data
+
+
+def test_fetch_threatfox_return_empty(monkeypatch):
+    def fail_post(*args, **kwargs):
+        raise RuntimeError('network')
+
+    monkeypatch.setattr('ioc_feeds.fetchers.threatfox.requests.post', fail_post)
+    # should not raise when raise_on_fail=False
+    result = fetch_threatfox('u', {}, retries=1, raise_on_fail=False)
+    assert result == []
+

--- a/ioc_feeds/tests/test_run_etl.py
+++ b/ioc_feeds/tests/test_run_etl.py
@@ -1,0 +1,41 @@
+import yaml
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from ioc_feeds import main_etl
+
+
+def test_run_etl_threatfox_failure(tmp_path, monkeypatch):
+    config = {
+        'sources': {
+            'blocklist_de': {'url': 'dummy', 'type': 'ip'},
+            'threatfox': {'url': 'dummy', 'api_payload': {'query': 'get_iocs'}},
+        },
+        'output': {
+            'database': str(tmp_path / 'db.duckdb'),
+            'csv_backup': None,
+        },
+    }
+    cfg_path = tmp_path / 'config.yaml'
+    cfg_path.write_text(yaml.dump(config))
+
+    inserted = []
+
+    class DummyHandler:
+        def __init__(self, db_path, csv_backup=None):
+            pass
+
+        def insert_many(self, records):
+            inserted.extend(records)
+
+    monkeypatch.setattr(main_etl, 'DuckDBHandler', DummyHandler)
+    monkeypatch.setattr(main_etl, 'fetch_blocklist', lambda url: ['1.1.1.1'])
+    def failing_fetch(*args, **kwargs):
+        raise RuntimeError('fail')
+    monkeypatch.setattr(main_etl, 'fetch_threatfox', failing_fetch)
+
+    main_etl.run_etl(str(cfg_path))
+
+    assert len(inserted) == 1
+    assert inserted[0]['value'] == '1.1.1.1'


### PR DESCRIPTION
## Summary
- improve `fetch_threatfox` to optionally not raise on final retry
- continue ETL when ThreatFox fails
- test new error handling logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e1bdc180832f8a643bbda79bfe7f