### PR TITLE
Add ThreatFox API key support

### DIFF
--- a/ioc_feeds/config.yaml
+++ b/ioc_feeds/config.yaml
@@ -7,6 +7,11 @@ sources:
     api_payload:
       query: "get_iocs"
       days: 1
+    # Optional API key for authenticated requests
+    api_key: "YOUR_API_KEY"
+    # Optional custom headers for ThreatFox API
+    headers:
+      Accept: "application/json"
     type: "json"
 output:
   database: "./ioc_feeds/database/ioc_data.duckdb"

--- a/ioc_feeds/fetchers/threatfox.py
+++ b/ioc_feeds/fetchers/threatfox.py
@@ -2,14 +2,21 @@ import requests
 from loguru import logger
 
 
-def fetch_threatfox(url: str, payload: dict, retries: int = 3) -> list[dict]:
+def fetch_threatfox(url: str, payload: dict, headers: dict | None = None, retries: int = 3) -> list[dict]:
+    """Fetch IoCs from ThreatFox API with optional authentication headers."""
+
+    headers = headers.copy() if headers else {}
+    api_key = payload.pop("api_key", None) or headers.pop("api_key", None)
+    if api_key and "API-KEY" not in headers and "API-Key" not in headers:
+        headers["API-KEY"] = api_key
+
     for attempt in range(1, retries + 1):
         try:
             logger.info("Fetching ThreatFox data (attempt {}/{})", attempt, retries)
-            response = requests.post(url, json=payload, timeout=30)
+            response = requests.post(url, json=payload, headers=headers or None, timeout=30)
             response.raise_for_status()
             data = response.json()
-            return data.get('data', [])
+            return data.get("data", [])
         except Exception as e:
             logger.error("Error fetching ThreatFox: {}", e)
             if attempt == retries:

--- a/ioc_feeds/main_etl.py
+++ b/ioc_feeds/main_etl.py
@@ -31,7 +31,11 @@ def run_etl(config_path: str = 'config.yaml'):
 
     threat_cfg = config['sources'].get('threatfox')
     if threat_cfg:
-        data = fetch_threatfox(threat_cfg['url'], threat_cfg.get('api_payload', {}))
+        data = fetch_threatfox(
+            threat_cfg['url'],
+            threat_cfg.get('api_payload', {}),
+            threat_cfg.get('headers')
+        )
         records.extend(parse_threatfox(data, source='threatfox'))
 
     db_handler.insert_many(records)

--- a/tasks/01_ioc_etl_plan.md
+++ b/tasks/01_ioc_etl_plan.md
@@ -24,6 +24,10 @@
       api_payload:
         query: "get_iocs"
         days: 1
+      # Optional API key or custom headers
+      api_key: "YOUR_API_KEY"
+      headers:
+        Accept: "application/json"
       type: "json"
     nvd:
       url: "https://services.nvd.nist.gov/rest/json/cves/2.0"
@@ -46,8 +50,8 @@
       response = requests.get(url)
       return response.text.splitlines()
 
-  def fetch_threatfox(url, payload):
-      response = requests.post(url, json=payload)
+  def fetch_threatfox(url, payload, headers=None):
+      response = requests.post(url, json=payload, headers=headers)
       return response.json()['data']
 
   def fetch_nvd_cve(url):


### PR DESCRIPTION
## Summary
- extend `config.yaml` with optional ThreatFox `api_key` and `headers`
- update ThreatFox fetcher to use optional headers and API key
- pass headers from ETL configuration
- document new config options and updated pseudocode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e1bec43c832f99ed1b08b7d50f87